### PR TITLE
Update home.md to fix link to installation guide and then add it to the _toc

### DIFF
--- a/napari-workshops/_toc.yml
+++ b/napari-workshops/_toc.yml
@@ -4,14 +4,8 @@
 format: jb-book
 root: home
 chapters:
-- file: docs/build_your_workshop
-  sections:
-  - file: docs/deployment_guide
-  - file: docs/launching_binder
-- file: getting_started
-  sections:
-  - file: installation
-  - file: notebook_setup
+- file: installation
+- file: notebook_setup
 - file: intro_napari_GUI
 - file: plugins
 - file: notebooks/index

--- a/napari-workshops/home.md
+++ b/napari-workshops/home.md
@@ -7,7 +7,7 @@ napari plugin.
 
 ## Getting Started
 
-Use the [installation guide](./napari-workshops/installation.md) to prepare your environment and install napari and
+Use the [installation guide](./installation.md) to prepare your environment and install napari and
 its required dependencies.
 
 ## Part 1 - Using Python and napari to view and analyze imaging data


### PR DESCRIPTION
Fixing a copy-paste error from the README:
`home.md` is in `napari-workshops` while `README.md` is at the top level.
Also added the installation and notebook pages to the _toc in place of the `create a workshop` pages from the template.