### PR TITLE
Fix peaks in segmentation notebook

### DIFF
--- a/napari-workshops/notebooks/interactive_analysis.md
+++ b/napari-workshops/notebooks/interactive_analysis.md
@@ -150,14 +150,11 @@ Now we can try and identify the centers of each of the nuclei by finding peaks o
 peak_local_max = feature.peak_local_max(
     smoothed_distance,
     footprint=np.ones((7, 7), dtype=bool),
-    indices=False,
-    labels=measure.label(foreground_processed)
 )
-peaks = np.nonzero(peak_local_max)
 ```
 
 ```{code-cell} ipython3
-viewer.add_points(np.array(peaks).T, name='peaks', size=5, face_color='red');
+viewer.add_points(peak_local_max, name='peaks', size=5, face_color='red');
 ```
 
 ```{code-cell} ipython3

--- a/napari-workshops/notebooks/interactive_analysis.md
+++ b/napari-workshops/notebooks/interactive_analysis.md
@@ -179,7 +179,6 @@ Based on those peaks we can now seed the watershed algorithm which will find the
 ```{code-cell} ipython3
 markers = util.label_points(viewer.layers['peaks'].data, output_shape=viewer.layers['nuclei_mip'].data.shape)
 
-markers = measure.label(seeds)
 nuclei_segmentation = segmentation.watershed(
     -smoothed_distance, 
     markers, 

--- a/napari-workshops/notebooks/interactive_analysis.md
+++ b/napari-workshops/notebooks/interactive_analysis.md
@@ -39,13 +39,36 @@ from napari.utils import nbscreenshot
 viewer = napari.Viewer()
 ```
 
-Let's read the original image from previous lessons, take a maximum projection, and view it in napari:
+There are multiple ways of reading image data into napari: drag-and-drop, **File > Open**, or programmatic reading.  
+For example, we could explicitly load a 3D image using the `tifffile` library and then use the `add_image()` method of our existing `Viewer` object named `viewer`. This approach allows you to load data into napari even if a Reader plugin doesn't exist for that file format!
+
+```Python
+import napari
+from tifffile import imread
+
+# load the image data using tifffile
+nuclei = imread('data/nuclei.tif')
+viewer.add_image(nuclei)
+```
+
+However, here, for simplicity, we will use the [`cells3d` dataset, provided by scikit-image](https://scikit-image.org/docs/stable/api/skimage.data.html#skimage.data.cells3d). 
+
+```{code-cell} ipython3
+from skimage.data import cells3d
+
+image_data = cells3d()  # shape (60, 2, 256, 256)
+
+membranes = image_data[:, 0, :, :]
+nuclei = image_data[:, 1, :, :]
+```
+
+Further, we will compute a maximum intensity projection of the nuclei data, reducing the dimensionality of the data from 3D to 2D, prior to adding the image to the viewer.  
 
 ```{code-cell} ipython3
 from tifffile import imread
 
-# load the image data and inspect its shape
-nuclei_mip = imread('data/nuclei.tif').max(axis=0)
+# calculate max projection using numpy method
+nuclei_mip = nuclei.max(axis=0)
 print(nuclei_mip.shape)
 ```
 

--- a/napari-workshops/notebooks/interactive_analysis.md
+++ b/napari-workshops/notebooks/interactive_analysis.md
@@ -150,6 +150,7 @@ Now we can try and identify the centers of each of the nuclei by finding peaks o
 peak_local_max = feature.peak_local_max(
     smoothed_distance,
     min_distance=7,
+    exclude_border=False
 )
 ```
 

--- a/napari-workshops/notebooks/interactive_analysis.md
+++ b/napari-workshops/notebooks/interactive_analysis.md
@@ -65,11 +65,10 @@ nuclei = image_data[:, 1, :, :]
 Further, we will compute a maximum intensity projection of the nuclei data, reducing the dimensionality of the data from 3D to 2D, prior to adding the image to the viewer.  
 
 ```{code-cell} ipython3
-from tifffile import imread
-
+print('Shape of nuclei array: ', nuclei.shape)
 # calculate max projection using numpy method
 nuclei_mip = nuclei.max(axis=0)
-print(nuclei_mip.shape)
+print('Shape of max projection of nuclei: ', nuclei_mip.shape)
 ```
 
 ```{code-cell} ipython3

--- a/napari-workshops/notebooks/interactive_analysis.md
+++ b/napari-workshops/notebooks/interactive_analysis.md
@@ -149,7 +149,7 @@ Now we can try and identify the centers of each of the nuclei by finding peaks o
 ```{code-cell} ipython3
 peak_local_max = feature.peak_local_max(
     smoothed_distance,
-    footprint=np.ones((7, 7), dtype=bool),
+    min_distance=7,
 )
 ```
 


### PR DESCRIPTION
Update for lastest skimage.
I simplified a bit by using min_distance instead of a footprint, which is easier to explain and then use the helper function from skimage instead of the multiline conversion.
Use bool to silence warning.