### PR TITLE
Move preferences to the end and simplify layer types section

### DIFF
--- a/napari-workshops/intro_napari_GUI.md
+++ b/napari-workshops/intro_napari_GUI.md
@@ -24,6 +24,14 @@ Once you have the proper environment active, you can launch napari by typing `na
 napari
 ```
 
+````{note}
+If you are using [the Binder cloud setup](docs/launching_binder.md), then in the Binder Jupyter lab interface, you can open a Desktop in a browser tab using the `D` "Desktop" tile and then open a Terminal session using the `$_` "Terminal" tile. In this terminal, you can launch napari in the Desktop browser tab using the command:
+```bash
+DISPLAY=:1.0 napari
+```
+You will then be able to proceed with the rest of the instructions on this page.
+````
+
 After a few seconds (or up to a minute if it's the first launch and you have various security and antivirus software installed), you will get the `viewer` window, which is annotated below:
 
 ![Viewer](resources/viewer-with-arrows.png)  

--- a/napari-workshops/notebooks/interactive_analysis.md
+++ b/napari-workshops/notebooks/interactive_analysis.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.17.1
+    jupytext_version: 1.16.7
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -51,7 +51,7 @@ nuclei = imread('data/nuclei.tif')
 viewer.add_image(nuclei)
 ```
 
-However, here, for simplicity, we will use the [`cells3d` dataset, provided by scikit-image](https://scikit-image.org/docs/stable/api/skimage.data.html#skimage.data.cells3d). 
+However, here, for simplicity, we will use the [`cells3d` dataset, provided by scikit-image](https://scikit-image.org/docs/stable/api/skimage.data.html#skimage.data.cells3d).
 
 ```{code-cell} ipython3
 from skimage.data import cells3d
@@ -62,7 +62,7 @@ membranes = image_data[:, 0, :, :]
 nuclei = image_data[:, 1, :, :]
 ```
 
-Further, we will compute a maximum intensity projection of the nuclei data, reducing the dimensionality of the data from 3D to 2D, prior to adding the image to the viewer.  
+Further, we will compute a maximum intensity projection of the nuclei data, reducing the dimensionality of the data from 3D to 2D, prior to adding the image to the viewer.
 
 ```{code-cell} ipython3
 print('Shape of nuclei array: ', nuclei.shape)

--- a/napari-workshops/notebooks/spot_detection_functions.md
+++ b/napari-workshops/notebooks/spot_detection_functions.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.1
+    jupytext_version: 1.16.7
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -155,7 +155,7 @@ Press the `Run` button and you will see that a new Image layer is added with the
 function—again thanks to autogeneration from `magicgui`.
 
 ```{code-cell} ipython3
-:tags: ["hide-output"]
+:tags: [hide-output]
 
 # we'll call the widget to simulate clicking `Run`
 gaussian_high_pass(viewer.layers['spots'].data)
@@ -353,7 +353,7 @@ viewer.window.add_dock_widget(detect_spots)
 ```
 
 ```{code-cell} ipython3
-:tags: ["hide-output"]
+:tags: [hide-output]
 
 # let's call the widget/function to simulate pressing run
 detect_spots(viewer.layers['spots'])
@@ -393,7 +393,6 @@ from napari.layers import Points
 @Points.bind_key("Shift-D")
 def print_number_of_points(points_layer: "napari.layers.Points"):
     print("Detected points: ", len(points_layer.data))
-
 ```
 
 Give it a shot in the viewer, you should get a print statement in the notebook, when you press the 
@@ -407,6 +406,7 @@ happen.
 ```
 
 Let's call the function to trigger it for the notebook:
+
 ```{code-cell} ipython3
 print_number_of_points(viewer.layers['Points'])
 ```


### PR DESCRIPTION
As discussed in prior meeting, this PR moves the `Preferences` section to the end of the tutorial, and simplifies the layer types section to just suggest looking at labels layer, as we were concerned about the time it would take if we left it fully exploratory.

I will update screenshots in a separate PR.